### PR TITLE
Fixes for Crystal 0.19

### DIFF
--- a/spec/spec-kemal_spec.cr
+++ b/spec/spec-kemal_spec.cr
@@ -10,7 +10,7 @@ describe "SpecKemalApp" do
 
   it "handles post" do
     json_body = {"name": "Serdar", "age": 27, "skills": ["crystal, kemal"]}
-    post("/user", headers: HTTP::Headers{"Content-Type": "application/json"}, body: json_body.to_json)
+    post("/user", headers: HTTP::Headers{"Content-Type" => "application/json"}, body: json_body.to_json)
     response.body.should eq(json_body.to_json)
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ end
 post "/user" do |env|
   env.response.content_type = "application/json"
   name = env.params.json["name"]
-  age = env.params.json["age"] as Int
-  skills = env.params.json["skills"] as Array
+  age = env.params.json["age"]
+  skills = env.params.json["skills"]
   {"name": name, "age": age, "skills": skills}.to_json
 end

--- a/src/spec-kemal.cr
+++ b/src/spec-kemal.cr
@@ -12,7 +12,17 @@ Kemal.config.host_binding = APP_HOST_BINDING
 Kemal.config.port = APP_PORT
 Kemal.config.logging = false
 
-$response : HTTP::Client::Response?
+class Global
+  @@response : HTTP::Client::Response?
+
+  def self.response=(@@response)
+  end
+
+  def self.response
+    @@response
+  end
+
+end
 
 def start
   spawn do
@@ -29,10 +39,10 @@ end
 
 {% for method in %w(get post put head delete patch) %}
   def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
-    $response = HTTP::Client.{{method.id}}(APP_URL + path, headers, body)
+    Global.response = HTTP::Client.{{method.id}}(APP_URL + path, headers, body)
   end
 {% end %}
 
 def response
-  $response.not_nil!
+  Global.response.not_nil!
 end


### PR DESCRIPTION
This PR fixes the issues with Crystal 0.19:
- Deprecated `$global` variables
- Deprecated `as` syntax
- Use `=>` for Hash like literal

The specs pass with 0.19. 
