### PR TITLE
call Kemal.config.setup

### DIFF
--- a/src/spec-kemal.cr
+++ b/src/spec-kemal.cr
@@ -22,7 +22,7 @@ end
 {% end %}
 
 def process_request(request)
-  io = MemoryIO.new
+  io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
   main_handler = build_main_handler
@@ -34,6 +34,7 @@ def process_request(request)
 end
 
 def build_main_handler
+  Kemal.config.setup
   main_handler = Kemal.config.handlers.first
   current_handler = main_handler
   Kemal.config.handlers.each_with_index do |handler, index|


### PR DESCRIPTION
I did this because without calling setup, the call to handlers fails
with and index out of bounds since the handlers do not exist yet.