### PR TITLE
Added 'options' test helper

### DIFF
--- a/shard.lock
+++ b/shard.lock
@@ -2,11 +2,11 @@ version: 1.0
 shards:
   exception_page:
     github: crystal-loot/exception_page
-    version: 0.1.1
+    version: 0.1.4
 
   kemal:
     github: sdogruyol/kemal
-    version: 0.25.1
+    version: 0.26.1
 
   kilt:
     github: jeromegn/kilt
@@ -14,5 +14,5 @@ shards:
 
   radix:
     github: luislavena/radix
-    version: 0.3.8
+    version: 0.3.9
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.5.0
 development_dependencies:
   kemal:
     github: sdogruyol/kemal
-    version: 0.25.1
+    version: 0.26.1
 
 authors:
   - Sdogruyol <dogruyolserdar@gmail.com>

--- a/spec/spec-kemal_spec.cr
+++ b/spec/spec-kemal_spec.cr
@@ -17,4 +17,12 @@ describe "SpecKemalApp" do
     post("/user", headers: HTTP::Headers{"Content-Type" => "application/json"}, body: json_body.to_json)
     response.body.should eq(json_body.to_json)
   end
+
+  it "handles options" do
+    options "/user" do |env|
+      "Hello world"
+    end
+    options "/user"
+    response.body.should eq "Hello world"
+  end
 end

--- a/src/spec-kemal.cr
+++ b/src/spec-kemal.cr
@@ -14,7 +14,7 @@ class Global
   end
 end
 
-{% for method in %w(get post put head delete patch) %}
+{% for method in %w(get post put head delete patch options) %}
   def {{method.id}}(path, headers : HTTP::Headers? = nil, body : String? = nil)
     request = HTTP::Request.new("{{method.id}}".upcase, path, headers, body )
     Global.response = process_request request

--- a/src/spec-kemal/version.cr
+++ b/src/spec-kemal/version.cr
@@ -1,3 +1,3 @@
 module Spec::Kemal
-  VERSION = "0.3.0"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
Added an `options` test helper method. Useful for testing CORS pre-flight handlers etc.

I've also updated to the latest version of `kemal` and bumped the `spec-kemal` version to match the incremented git tag.

This PR addresses and resolves issue #18 (that I raised).