### PR TITLE
Version bump to 0.5.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: spec-kemal
-version: 0.5.0
+version: 0.5.1
 crystal: '< 2.0.0'
 
 development_dependencies:

--- a/src/spec-kemal/version.cr
+++ b/src/spec-kemal/version.cr
@@ -1,3 +1,3 @@
 module Spec::Kemal
-  VERSION = "0.3.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
Hello, I'm new to Crystal & Kemal. I ran into this issue when adding `spec-kemal` to a project of mine:

<img width="1120" alt="Screen Shot 2021-04-24 at 10 02 08" src="https://user-images.githubusercontent.com/6045239/115964962-25496d80-a4e4-11eb-8f71-88612678f230.png">

Apparently releases (git tags) take precedence over the master branch. Despite #20 being merged we need a `0.5.1` (or minor bump) release for it to work "out of the box".

When I did this everything worked fine:

```yaml
dependencies:
  kemal:
    github: kemalcr/kemal
  spec-kemal:
    github: kemalcr/spec-kemal
    branch: master
```

<img width="487" alt="Screen Shot 2021-04-24 at 10 06 18" src="https://user-images.githubusercontent.com/6045239/115965140-d8b26200-a4e4-11eb-8e07-7fe354e3b2da.png">

Once merged please create a git tag (release) for it. I hope this helps.

Thank you for all the work on the framework, it's very cool.