### PR TITLE
added section about Kemal.config.always_rescue

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,7 @@ end
 #### Rescue errors
 Errors gets rescued by default which results in the Kemal's exception page is rendered.  
 This may not always be the desired behaviour, e.g. when a JSON parsing error occurs one might expect `"[]"`
-and not Kemal's exception page.
-
-```
-Expected: "[]"
-Got: "<!DOCTYPE html>\n<html>\n<head>\n    \n    <meta charset=\"utf-8\">\n    <title>Error 500 at GET / - Missing JSON attribute: names</title>\n    <meta name=\"viewport\" content=\"width=device-width\">\n    <style>/*! normalize.css v4.2.0 | MIT License | github.
-```
+and not Kemal's exception page.  
 
 Set `Kemal.config.always_rescue = false` to prevent this behaviour and raise errors instead.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,18 @@ describe "Your::Kemal::App" do
 end
 ```
 
+#### Rescue errors
+Errors gets rescued by default which results in the Kemal's exception page is rendered.  
+This may not always be the desired behaviour, e.g. when a JSON parsing error occurs one might expect `"[]"`
+and not Kemal's exception page.
+
+```
+Expected: "[]"
+Got: "<!DOCTYPE html>\n<html>\n<head>\n    \n    <meta charset=\"utf-8\">\n    <title>Error 500 at GET / - Missing JSON attribute: names</title>\n    <meta name=\"viewport\" content=\"width=device-width\">\n    <style>/*! normalize.css v4.2.0 | MIT License | github.
+```
+
+Set `Kemal.config.always_rescue = false` to prevent this behaviour and raise errors instead.
+
 ## Contributing
 
 1. Fork it ( https://github.com/kemalcr/spec-kemal/fork )


### PR DESCRIPTION
As mentioned in #17 having Kemal's exception page rendered may not always be the desired behaviour when testing. It is also not obvious that this behaviour can be changed by setting `Kemal.config.always_rescue = false` because one would have to look in Kemal's source code to find this property.

This PR adds a short section to the README that informs developers about `Kemal.config.always_rescue`.