### PR TITLE
Add support to write tests with kemal-session.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,26 @@ describe "Your::Kemal::App" do
 end
 ```
 
+### Kemal Session
+
+If you are using [Kemal Session](https://github.com/kemalcr/kemal-session) in your application it's possible to test session related features as well.
+
+To do that require `"spec-kemal/session"` instead of just `spec-kemal`, then
+you can use `with_session` to create a session for your requests.
+
+```crystal
+require "spec-kemal/session"
+
+it "works with sessions" do
+  with_session do |session|
+    session.bigint("user_id", 12345) # sets a session value
+
+    get "/dashboard"
+    response.body.should eq "session value"
+  end
+end
+```
+
 #### Rescue errors
 Errors gets rescued by default which results in the Kemal's exception page is rendered.  
 This may not always be the desired behaviour, e.g. when a JSON parsing error occurs one might expect `"[]"`

--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,8 @@ crystal: '< 2.0.0'
 development_dependencies:
   kemal:
     github: kemalcr/kemal
-    version: 1.0.0
+  kemal-session:
+    github: kemalcr/kemal-session
 
 authors:
   - Sdogruyol <dogruyolserdar@gmail.com>

--- a/spec/spec-kemal_spec.cr
+++ b/spec/spec-kemal_spec.cr
@@ -17,4 +17,16 @@ describe "SpecKemalApp" do
     post("/user", headers: HTTP::Headers{"Content-Type" => "application/json"}, body: json_body.to_json)
     response.body.should eq(json_body.to_json)
   end
+
+  it "handles sessions" do
+    get "/session_var" do |env|
+      env.session.string?(env.params.query["key"]) || "not found"
+    end
+
+    with_session do |session|
+      session.string("hey ho!", "let's go! 🎸")
+      get "/session_var?key=hey+ho!"
+      response.body.should eq("let's go! 🎸")
+    end
+  end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,10 +1,14 @@
 require "spec"
 require "kemal"
+require "kemal-session"
+
 require "../src/spec-kemal"
+require "../src/spec-kemal/session"
 
 Spec.before_each do
   config = Kemal.config
   config.env = "test"
+  Kemal::Session.config.secret = "🤫"
   config.setup
 end
 

--- a/src/spec-kemal/session.cr
+++ b/src/spec-kemal/session.cr
@@ -1,0 +1,27 @@
+require "kemal-session"
+
+class Global
+  class_property? session : Kemal::Session?
+end
+
+private def create_session : Kemal::Session
+  raise "Kemal session secret not set." if Kemal::Session.config.secret.empty?
+
+  destroy_session
+  Global.session = Kemal::Session.new(Random::Secure.hex)
+end
+
+# Creates a new session, yields it to the block, and ensures it is destroyed afterwards.
+#
+# All spec-kemal requests made within the block will use this session.
+def with_session(&)
+  session = create_session
+  yield session
+ensure
+  destroy_session
+end
+
+private def destroy_session
+  Global.session?.try(&.destroy)
+  Global.session = nil
+end


### PR DESCRIPTION
By default spec-kemal still not depending on kemal-session, but if you require "spec-kemal/session", "kemal-session" dependency must be added to shard.yml.

*How to use*

```
require "spec-kemal/session"

it "handles sessions" do
  get "/session_var" do |env|
    env.session.string?(env.params.query["key"]) || "not found"
  end

  with_session do |session|
    session.string("hey ho!", "let's go! 🎸")
    get "/session_var?key=hey+ho!"
    response.body.should eq("let's go! 🎸")
  end
end
```