### PR TITLE
Add WebSocket Testing Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Testing helpers for the [Kemal](https://kemalcr.com) web framework. Write expres
 - [Quick Start](#quick-start)
 - [API Reference](#api-reference)
   - [HTTP Methods](#http-methods)
+  - [WebSocket testing](#websocket-testing)
   - [Response Object](#response-object)
   - [Headers](#headers)
   - [Request Body](#request-body)
@@ -118,6 +119,99 @@ spec-kemal provides helper methods for all standard HTTP verbs:
 - `path : String` - The request path (e.g., `"/users"`, `"/api/v1/posts?page=2"`)
 - `headers : HTTP::Headers?` - Optional HTTP headers
 - `body : String?` - Optional request body
+
+An additional overload is available for GET with a WebSocket handshake:
+
+- `get(path, headers?, body?, *, websocket : Bool)` — when `websocket` is `true`, builds a valid `Upgrade: websocket` request (see [WebSocket testing](#websocket-testing)).
+
+### WebSocket testing
+
+Kemal exposes WebSockets with `ws "/path"`. spec-kemal splits testing into **handshake-only** (fast, in-memory) and **full duplex** (real upgrade, your `on_message` runs).
+
+| Approach | API | `ws` handler runs? | Typical assertions |
+|----------|-----|-------------------|--------------------|
+| Handshake only | `get path, websocket: true` or `SpecKemal.process_request` + `websocket_request_headers` | No | **101**, `Sec-WebSocket-Accept`, **400** / **426** on bad requests |
+| Messages | `connect_websocket` | Yes | Echo, broadcast, auth via `Origin` / cookies |
+
+Handshake-only requests go through `SpecKemal.process_request`, which does **not** call [HTTP::Server::Response#upgrade_handler](https://crystal-lang.org/api/latest/HTTP/Server/Response.html). That matches normal `get`/`post` helpers: the route is matched and the upgrade response is built, but no WebSocket I/O runs. Use `connect_websocket` whenever you need `socket.on_message`, pings, or closing behavior.
+
+Assume an echo route (adjust the path to your app):
+
+```crystal
+ws "/chat" do |socket, _env|
+  socket.on_message { |message| socket.send message }
+end
+```
+
+#### Handshake-only (`get …, websocket: true`)
+
+```crystal
+get "/chat", websocket: true
+
+response.status_code.should eq 101
+response.headers["Upgrade"].should eq "websocket"
+```
+
+To assert `Sec-WebSocket-Accept` for a **known** key (RFC 6455 test vector), pass headers from `websocket_request_headers(sec_key:)` into `get` (`connect_websocket` also accepts `sec_key:` for the same purpose):
+
+```crystal
+key = "dGhlIHNhbXBsZSBub25jZQ=="
+headers = websocket_request_headers(sec_key: key)
+get "/chat", headers: headers, websocket: true
+
+response.status_code.should eq 101
+response.headers["Sec-WebSocket-Accept"].should eq HTTP::WebSocket::Protocol.key_challenge(key)
+```
+
+Invalid handshakes are ordinary HTTP responses — still in-memory (reuse the same `/chat` route):
+
+```crystal
+bad = websocket_request_headers
+bad.delete "Sec-WebSocket-Key"
+SpecKemal.process_request HTTP::Request.new("GET", "/chat", bad)
+response.status_code.should eq 400
+
+bad = websocket_request_headers
+bad["Sec-WebSocket-Version"] = "7"
+SpecKemal.process_request HTTP::Request.new("GET", "/chat", bad)
+response.status_code.should eq 426
+```
+
+#### Full session (`connect_websocket`)
+
+Runs the real upgrade on a loopback socket pair (UNIX socket pair on Unix-like systems, TCP on Windows), then yields a client [HTTP::WebSocket](https://crystal-lang.org/api/latest/HTTP/WebSocket.html). After the block returns, the client and server I/O are closed. The last `response` is the client’s **101 Switching Protocols** handshake.
+
+Pattern: register `on_message`, **spawn** `client.run` so frames are processed, **yield** once so the fiber starts, then `send` / assert on a `Channel`:
+
+```crystal
+connect_websocket "/chat" do |client|
+  replies = Channel(String).new(1)
+  client.on_message { |message| replies.send message }
+  spawn { client.run }
+  Fiber.yield
+
+  client.send "hello"
+  replies.receive.should eq "hello"
+end
+
+response.status_code.should eq 101
+```
+
+Optional keyword arguments on `connect_websocket`:
+
+- `headers` — merged after the default WebSocket upgrade headers (e.g. `Authorization`, extra cookies).
+- `sec_key` — fixed `Sec-WebSocket-Key` for deterministic `Sec-WebSocket-Accept` checks.
+- `origin` — sets `Origin` when your handler rejects unknown origins.
+
+```crystal
+connect_websocket "/chat", origin: "https://myapp.test" do |client|
+  # ...
+end
+```
+
+For the same handshake object **inside** the block (not only via `response` after), use `inner_connect_websocket` (advanced; see `src/spec-kemal/websocket.cr`).
+
+When you `require "spec-kemal/session"`, cookies from `with_session` apply to both `get(..., websocket: true)` and `connect_websocket`, the same as for normal HTTP helpers.
 
 ### Response Object
 

--- a/spec/spec-kemal_spec.cr
+++ b/spec/spec-kemal_spec.cr
@@ -513,4 +513,47 @@ describe "spec-kemal" do
       response.body.size.should eq 10000
     end
   end
+
+  describe "WebSocket" do
+    it "returns 101 and Sec-WebSocket-Accept for a valid upgrade (in-memory; ws block not run)" do
+      ws "/ws-mem" do |socket, _|
+        socket.on_message { |_| socket.send "never" }
+      end
+      get "/ws-mem", websocket: true
+      key = "dGhlIHNhbXBsZSBub25jZQ=="
+      response.status_code.should eq 101
+      response.headers["Sec-WebSocket-Accept"].should eq \
+        HTTP::WebSocket::Protocol.key_challenge(key)
+    end
+
+    it "rejects bad Sec-WebSocket-Version" do
+      ws "/ws-ver" { |_| }
+      h = websocket_request_headers
+      h["Sec-WebSocket-Version"] = "7"
+      SpecKemal.process_request(HTTP::Request.new("GET", "/ws-ver", h, nil))
+      response.status_code.should eq 426
+    end
+
+    it "rejects missing Sec-WebSocket-Key" do
+      ws "/ws-key" { |_| }
+      h = websocket_request_headers
+      h.delete "Sec-WebSocket-Key"
+      SpecKemal.process_request(HTTP::Request.new("GET", "/ws-key", h, nil))
+      response.status_code.should eq 400
+    end
+
+    it "connect_websocket runs ws handler and exchanges messages" do
+      ws "/ws-echo" do |socket, _|
+        socket.on_message { |message| socket.send message }
+      end
+      ch = Channel(String).new(1)
+      connect_websocket "/ws-echo" do |client|
+        client.on_message { |message| ch.send message }
+        spawn { client.run }
+        Fiber.yield
+        client.send "ping"
+        ch.receive.should eq "ping"
+      end
+    end
+  end
 end

--- a/src/spec-kemal.cr
+++ b/src/spec-kemal.cr
@@ -32,6 +32,39 @@ require "kemal"
 # Disable logging by default for cleaner test output
 Kemal.config.logging = false
 
+# Links Kemal's [HTTP::Handler] chain. Used by [process_request] and [./spec-kemal/websocket] WebSocket flow.
+module SpecKemal
+  def self.build_main_handler : HTTP::Handler
+    main_handler = Kemal.config.handlers.first
+    current_handler = main_handler
+
+    Kemal.config.handlers.each do |handler|
+      current_handler.next = handler
+      current_handler = handler
+    end
+
+    main_handler
+  end
+
+  # In-memory handler run. Does **not** call [HTTP::Server::Response#upgrade_handler]; use
+  # the top-level `connect_websocket` helper for full WebSocket message tests.
+  def self.process_request(request : HTTP::Request) : HTTP::Client::Response
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+
+    SessionInjector.run(request)
+
+    context = HTTP::Server::Context.new(request, response)
+    main_handler = build_main_handler
+    main_handler.call(context)
+
+    response.close
+    io.rewind
+    client_response = HTTP::Client::Response.from_io(io, decompress: false)
+    Global.response = client_response
+  end
+end
+
 # Internal hook for session cookie injection. When spec-kemal/session is required,
 # it registers a callback here. This avoids referencing Global.session? in the
 # base library, which would fail to compile when the session extension is not used.
@@ -109,55 +142,9 @@ end
   # ```
   def {{ method.id }}(path : String, headers : HTTP::Headers? = nil, body : String? = nil) : HTTP::Client::Response
     request = HTTP::Request.new("{{ method.id }}".upcase, path, headers, body)
-    process_request(request)
+    SpecKemal.process_request(request)
   end
 {% end %}
-
-# Processes an HTTP request through Kemal's handler chain.
-#
-# This method simulates a full HTTP request/response cycle by:
-# 1. Creating an in-memory IO for the response
-# 2. Injecting session cookies if session support is enabled
-# 3. Building and executing the Kemal handler chain
-# 4. Parsing and returning the response
-#
-# NOTE: This is a private method used internally by the HTTP helper methods.
-private def process_request(request : HTTP::Request) : HTTP::Client::Response
-  io = IO::Memory.new
-  response = HTTP::Server::Response.new(io)
-
-  # Inject session cookie if session support is loaded (callback registered by spec-kemal/session).
-  SessionInjector.run(request)
-
-  # Create the server context and process through handlers
-  context = HTTP::Server::Context.new(request, response)
-  main_handler = build_main_handler
-  main_handler.call(context)
-
-  # Close the response and parse it as a client response
-  response.close
-  io.rewind
-  client_response = HTTP::Client::Response.from_io(io, decompress: false)
-  Global.response = client_response
-end
-
-# Builds the Kemal handler chain by linking all configured handlers together.
-#
-# Kemal uses a chain of handlers (middleware) to process requests.
-# This method links them together so each handler can call the next.
-#
-# NOTE: This is a private method used internally.
-private def build_main_handler : HTTP::Handler
-  main_handler = Kemal.config.handlers.first
-  current_handler = main_handler
-
-  Kemal.config.handlers.each do |handler|
-    current_handler.next = handler
-    current_handler = handler
-  end
-
-  main_handler
-end
 
 # Returns the response from the last HTTP request.
 #
@@ -191,3 +178,5 @@ def response : HTTP::Client::Response
   Global.response.not_nil!
   # ameba:enable Lint/NotNil
 end
+
+require "./spec-kemal/websocket"

--- a/src/spec-kemal/websocket.cr
+++ b/src/spec-kemal/websocket.cr
@@ -1,0 +1,140 @@
+require "http/web_socket"
+require "socket"
+
+# WebSocket test helpers. See the **WebSocket** section in the spec-kemal README.
+#
+# * **Handshake (in-memory)**: `get` with `websocket: true` or [websocket_request_headers] — the
+#   `ws` block does not run (no [upgrade_handler] in [SpecKemal.process_request]).
+# * **Session (duplex)**: [connect_websocket] — full WebSocket; uses a socket pair
+#   and calls `response.upgrade_handler` like [HTTP::Server::RequestProcessor].
+
+# :nodoc:
+DEFAULT_WEBSOCKET_KEY = "dGhlIHNhbXBsZSBub25jZQ=="
+
+# Returns headers for a valid WebSocket upgrade request.
+# Use a fixed *sec_key* for deterministic [Sec-WebSocket-Accept] in assertions, or pass `nil` to use
+# [DEFAULT_WEBSOCKET_KEY] (RFC 6455 example value).
+def websocket_request_headers(
+  sec_key : String? = nil,
+  origin : String? = nil,
+) : HTTP::Headers
+  key = sec_key || DEFAULT_WEBSOCKET_KEY
+  headers = HTTP::Headers{
+    "Connection"            => "Upgrade",
+    "Upgrade"               => "websocket",
+    "Sec-WebSocket-Version" => HTTP::WebSocket::Protocol::VERSION,
+    "Sec-WebSocket-Key"     => key,
+  }
+  if o = origin
+    headers["Origin"] = o
+  end
+  headers
+end
+
+# [GET] with a WebSocket-style handshake. Merges [websocket_request_headers] when *websocket* is `true`
+# (*headers* override defaults for duplicate keys).
+# The response is still in-memory [SpecKemal.process_request] — the `ws` route *handler* (e.g. [on_message])
+# is **not** run; use [connect_websocket] for that.
+def get(
+  path : String,
+  headers : HTTP::Headers? = nil,
+  body : String? = nil,
+  *,
+  websocket : Bool,
+) : HTTP::Client::Response
+  h = (headers || HTTP::Headers.new).dup
+  if websocket
+    w = websocket_request_headers
+    w.merge! h
+    h = w
+  end
+  SpecKemal.process_request(HTTP::Request.new("GET", path, h, body))
+end
+
+# Duplex WebSocket: runs Kemal *ws* code on a real connection, then gives you a client [HTTP::WebSocket].
+#
+# The last [response] is the **101** as seen by the client. The block can send and receive messages.
+# After the block, the client WebSocket and connection I/Os are closed.
+def connect_websocket(
+  path : String,
+  headers : HTTP::Headers? = nil,
+  sec_key : String? = nil,
+  origin : String? = nil,
+  &block : HTTP::WebSocket -> Nil
+) : Nil
+  base = websocket_request_headers(sec_key: sec_key, origin: origin)
+  base.merge! headers if headers
+  request = HTTP::Request.new("GET", path, base, nil)
+  inner_connect_websocket(request) do |client_ws, _hs|
+    block.call(client_ws)
+  end
+end
+
+# :nodoc: — for advanced use (e.g. inspect the 101 in the same block)
+def inner_connect_websocket(
+  request : HTTP::Request,
+  &block : (HTTP::WebSocket, HTTP::Client::Response) -> Nil
+) : Nil
+  ex_ch = Channel(Exception?).new(1)
+  done = Channel(Nil).new(1)
+
+  server_io, client_io = connected_socket_pair
+  begin
+    response = HTTP::Server::Response.new(server_io)
+    SessionInjector.run(request)
+    context = HTTP::Server::Context.new(request, response)
+    main_handler = SpecKemal.build_main_handler
+    main_handler.call(context)
+
+    handshake = HTTP::Client::Response.from_io(client_io, ignore_body: true, decompress: false)
+    Global.response = handshake
+
+    upgrade = context.response.upgrade_handler
+    raise "Kemal did not set a WebSocket upgrade (status #{handshake.status_code}, path #{request.path})" unless upgrade
+
+    spawn(name: "spec-kemal-ws-upgrade") do
+      begin
+        upgrade.call(server_io)
+      rescue e : Exception
+        ex_ch.send e
+      else
+        ex_ch.send nil
+      end
+    ensure
+      done.send nil
+    end
+    spawned = true
+
+    Fiber.yield
+
+    client_ws = HTTP::WebSocket.new(HTTP::WebSocket::Protocol.new(client_io, masked: true, sync_close: true))
+    block.call(client_ws, handshake)
+  ensure
+    client_io.close rescue nil
+    server_io.close rescue nil
+  end
+  if spawned
+    ex = ex_ch.receive
+    raise ex if ex
+    done.receive
+  end
+end
+
+private def connected_socket_pair : {IO, IO}
+  {% if !flag?(:win32) %}
+    return UNIXSocket.pair
+  {% end %}
+
+  tcp = TCPServer.new("127.0.0.1", 0)
+  begin
+    local = tcp.local_address.as(Socket::IPAddress)
+    port = local.port
+    accept_ch = Channel(TCPSocket).new(1)
+    spawn { accept_ch.send tcp.accept.as(TCPSocket) }
+    client = TCPSocket.new("127.0.0.1", port)
+    server = accept_ch.receive
+    {server.as(IO), client.as(IO)}
+  ensure
+    tcp.close
+  end
+end


### PR DESCRIPTION
## Summary
Implements [#5](https://github.com/kemalcr/spec-kemal/issues/5)

Adds **two layers** of WebSocket testing for Kemal apps: in-memory **upgrade / handshake** checks, and **duplex** tests that run real message exchange over a socket pair.

## New helpers

- **`websocket_request_headers`** — Valid WebSocket upgrade headers; optional `sec_key` and `Origin`.
- **`get(path, …, websocket: true)`** — Merges upgrade headers and runs the request through `SpecKemal.process_request`. The **`ws` block does not run** (no `upgrade_handler`); use this for assertions on **101**, `Sec-WebSocket-Accept`, or **400** / **426** on bad handshakes.
- **`connect_websocket`** — Real upgrade via a connected socket pair (`UNIXSocket.pair` on Unix, loopback TCP on Windows); invokes `response.upgrade_handler` like production, and yields a client `HTTP::WebSocket` for send/receive in the block.
- **`inner_connect_websocket`** — Advanced: access both the client WebSocket and the **101** `HTTP::Client::Response` inside the block.

## Example

Assume your app prefixes server replies (so you can tell client send vs server send apart):

```crystal
ws "/chat" do |socket, _env|
  socket.on_message { |msg| socket.send "server: #{msg}" }
end
```
1. Handshake only — fast; the `ws` body never runs:
```crystal
get "/chat", websocket: true
response.status_code.should eq 101
response.headers["Upgrade"].should eq "websocket"
```
2. Real messages — runs the ws handler; assert the transformed reply, not the raw send:
```
connect_websocket "/chat" do |client|
  replies = Channel(String).new(1)
  client.on_message { |msg| replies.send msg }
  spawn { client.run }
  Fiber.yield

  client.send "hello"
  replies.receive.should eq "server: hello"
end
```